### PR TITLE
Fix simple dockerfile errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ COPY ./actix/Cargo.toml ./actix/Cargo.lock ./
 COPY ./actix/src ./src
 # Build application
 RUN cargo build --release --target=$target --locked --bin chhoto-url
+RUN cp /chhoto-url/target/$target/release/chhoto-url /chhoto-url/release
 
 FROM scratch
-COPY --from=builder /chhoto-url/target/$target/release/chhoto-url /chhoto-url
+COPY --from=builder /chhoto-url/release /chhoto-url
 COPY ./resources /resources
 ENTRYPOINT ["/chhoto-url"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@
 FROM lukemathwalker/cargo-chef:latest-rust-slim AS chef
 WORKDIR /chhoto-url
 
-FROM chef as planner
+FROM chef AS planner
 COPY ./actix/Cargo.toml ./actix/Cargo.lock ./
 COPY ./actix/src ./src
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef as builder
+FROM chef AS builder
 ARG target=x86_64-unknown-linux-musl
 RUN apt-get update && apt-get install -y musl-tools
 RUN rustup target add $target

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM lukemathwalker/cargo-chef:latest-rust-slim AS chef
 WORKDIR /chhoto-url
 
 FROM chef as planner
-COPY ./actix/Cargo.toml ./actix/Cargo.lock .
+COPY ./actix/Cargo.toml ./actix/Cargo.lock ./
 COPY ./actix/src ./src
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -18,7 +18,7 @@ COPY --from=planner /chhoto-url/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer
 RUN cargo chef cook --release --target=$target --recipe-path recipe.json
 
-COPY ./actix/Cargo.toml ./actix/Cargo.lock .
+COPY ./actix/Cargo.toml ./actix/Cargo.lock ./
 COPY ./actix/src ./src
 # Build application
 RUN cargo build --release --target=$target --locked --bin chhoto-url

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2023 Sayantan Santra <sayantan.santra689@gmail.com>
 # SPDX-License-Identifier: MIT
 
-FROM scratch as builder-amd64
+FROM scratch AS builder-amd64
 COPY ./actix/target/x86_64-unknown-linux-musl/release/chhoto-url /chhoto-url
 
-FROM scratch as builder-arm64
+FROM scratch AS builder-arm64
 COPY ./actix/target/aarch64-unknown-linux-musl/release/chhoto-url /chhoto-url
 
-FROM scratch as builder-arm
+FROM scratch AS builder-arm
 COPY ./actix/target/armv7-unknown-linux-musleabihf/release/chhoto-url /chhoto-url
 
 ARG TARGETARCH


### PR DESCRIPTION
PR fixes 2 errors I've faced when building the Dockerfile.

The errors:
1- When using COPY with more than one source file, the destination must be a directory and end with a /
2- $target argument not being passed

I don't know how you didn't face these errors before, maybe it is about the version changes.