### PR TITLE
Correctly output created link

### DIFF
--- a/actix/src/main.rs
+++ b/actix/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
     }
 
     // Tell the user that the server has started, and where it is listening to, rather than simply outputting nothing
-    eprintln!("Server has started at 0.0.0.0 on port 4567.");
+    eprintln!("Server has started at 0.0.0.0 on port {port}.");
 
     // Actually start the server
     HttpServer::new(move || {
@@ -113,7 +113,7 @@ async fn main() -> Result<()> {
             .default_service(actix_web::web::get().to(services::error404))
     })
     // Hardcode the port the server listens to. Allows for more intuitive Docker Compose port management
-    .bind(("0.0.0.0", 4567))?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
 }

--- a/actix/src/main.rs
+++ b/actix/src/main.rs
@@ -30,6 +30,7 @@ async fn main() -> Result<()> {
         .filter(|s| !s.trim().is_empty())
         .unwrap_or(String::from("urls.sqlite"));
 
+    // Get the port environment variable
     let port = env::var("port")
         .unwrap_or(String::from("4567"))
         .parse::<u16>()
@@ -42,17 +43,42 @@ async fn main() -> Result<()> {
     // If an API key is set, check the security
     if let Ok(key) = env::var("api_key") {
         if !auth::is_key_secure() {
-            eprintln!("API key is insecure! Please change it. Current key is: {}. Generated secure key which you may use: {}", key, auth::gen_key())
+            eprintln!("WARN: API key is insecure! Please change it. Current key is: {}. Generated secure key which you may use: {}", key, auth::gen_key())
         } else {
             eprintln!("Secure API key was provided.")
         }
     }
 
-    // Tell the user that the server has started, and where it is listening to, rather than simply outputting nothing
-    eprintln!("Server has started at 0.0.0.0 on port {port}.");
+    // If the site_url env variable exists
     if let Some(site_url) = env::var("site_url").ok().filter(|s| !s.trim().is_empty()) {
-        eprintln!("Configured Site URL is: {site_url}.");
+        // Get first and last characters of the site_url
+        let mut chars = site_url.chars();
+        let first = chars.next();
+        let last = chars.next_back();
+        let url = chars.as_str();
+        // If the site_url is encapsulated by quotes (i.e. invalid)
+        if first == Option::from('"') || first == Option::from('\'') && first == last {
+            // Set the site_url without the quotes
+            env::set_var("site_url", url);
+            eprintln!("WARN: The site_url environment variable is encapsulated by quotes. Automatically adjusting to {}", url);
+
+            // Tell the user what URI the server will respond with
+            eprintln!("INFO: Public URI is: {url}:{port}.")
+        } else {
+            // No issues
+            eprintln!("INFO: Configured Site URL is: {site_url}.");
+
+            // Tell the user what URI the server will respond with
+            eprintln!("INFO: Public URI is: {site_url}:{port}.")
+        }
+    } else {
+        // Site URL is not configured
+        eprintln!("WARN: The site_url environment variable is not configured. Defaulting to http://localhost");
+        eprintln!("INFO: Public URI is: http://localhost:{port}.")
     }
+
+    // Tell the user that the server has started, and where it is listening to, rather than simply outputting nothing
+    eprintln!("Server has started at 0.0.0.0 on port 4567.");
 
     // Actually start the server
     HttpServer::new(move || {
@@ -86,7 +112,8 @@ async fn main() -> Result<()> {
             .service(Files::new("/", "./resources/").index_file("index.html"))
             .default_service(actix_web::web::get().to(services::error404))
     })
-    .bind(("0.0.0.0", port))?
+    // Hardcode the port the server listens to. Allows for more intuitive Docker Compose port management
+    .bind(("0.0.0.0", 4567))?
     .run()
     .await
 }

--- a/actix/src/services.rs
+++ b/actix/src/services.rs
@@ -11,7 +11,6 @@ use actix_web::{
     Either, HttpRequest, HttpResponse, Responder,
 };
 use std::env;
-
 // Serialize JSON data
 use serde::Serialize;
 
@@ -68,7 +67,7 @@ pub async fn add_link(
                 .unwrap_or(String::from("4567"))
                 .parse::<u16>()
                 .expect("Supplied port is not an integer");
-            let url = format!(
+            let mut url = format!(
                 "{}:{}",
                 env::var("site_url")
                     .ok()
@@ -76,6 +75,22 @@ pub async fn add_link(
                     .unwrap_or(String::from("http://localhost")),
                 port
             );
+            // If the port is 80, remove the port from the returned URL (better for copying and pasting)
+            // Return http://
+            if port == 80 {
+                url = env::var("site_url")
+                        .ok()
+                        .filter(|s| !s.trim().is_empty())
+                        .unwrap_or(String::from("http://localhost"));
+            }
+            // If the port is 443, remove the port from the returned URL (better for copying and pasting)
+            // Return https://
+            if port == 443 {
+                url = env::var("site_url")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+                    .unwrap_or(String::from("https://localhost"));
+            }
             let response = CreatedURL {
                 success: true,
                 error: false,

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,8 @@ services:
         restart: unless-stopped
         container_name: chhoto-url
         ports:
+            # If you changed the "port" environment variable, adjust accordingly
+            # The number after the colon should match the "port" environment variable
             - 4567:4567
         environment:
             # Change if you want to mount the database somewhere else.
@@ -18,11 +20,17 @@ services:
             # a copy of your database.)
             - db_url=/db/urls.sqlite
 
-            # Change it in case you want to set the website name
-            # displayed in front of the shorturls, defaults to
-            # the hostname you're accessing it from.
+            # Change this if your server URL is not "http://localhost"
+            # This must not be surrounded by quotes. For example:
+            # site_url="https://www.example.com"   incorrect
+            # site_url=https://www.example.com     correct
+            # This is important to ensure Chhoto URL outputs the shortened link with the correct URL.
             # - site_url=https://www.example.com
 
+            # Change this if you are running Chhoto URL on a port which is not 4567.
+            # This is important to ensure Chhoto URL outputs the shortened link with the correct port.
+            # - port=4567
+            
             - password=TopSecretPass
 
             # This needs to be set in order to use programs that use the JSON interface of Chhoto URL.

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
         container_name: chhoto-url
         ports:
             # If you changed the "port" environment variable, adjust accordingly
-            # The number after the colon should match the "port" environment variable
+            # Both numbers before and after the colon should match the "port" variable
             - 4567:4567
         environment:
             # Change if you want to mount the database somewhere else.

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
         container_name: chhoto-url
         ports:
             # If you changed the "port" environment variable, adjust accordingly
-            # The number before the colon should match the "port" variable
+            # Both numbers before and after the colon should match the "port" variable
             - 4567:4567
         environment:
             # Change if you want to mount the database somewhere else.

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
             # This needs to be set in order to use programs that use the JSON interface of Chhoto URL.
             # You will get a warning if this is insecure, and a generated value will be output
             # You may use that value if you can't think of a secure key
-            - api_key=SECURE_API_KEY
+            # - api_key=SECURE_API_KEY
 
             # Pass the redirect method, if needed. TEMPORARY and PERMANENT
             # are accepted values, defaults to PERMANENT.

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
         container_name: chhoto-url
         ports:
             # If you changed the "port" environment variable, adjust accordingly
-            # Both numbers before and after the colon should match the "port" variable
+            # The number before the colon should match the "port" variable
             - 4567:4567
         environment:
             # Change if you want to mount the database somewhere else.
@@ -36,7 +36,7 @@ services:
             # This needs to be set in order to use programs that use the JSON interface of Chhoto URL.
             # You will get a warning if this is insecure, and a generated value will be output
             # You may use that value if you can't think of a secure key
-            # - api_key=SECURE_API_KEY
+            - api_key=SECURE_API_KEY
 
             # Pass the redirect method, if needed. TEMPORARY and PERMANENT
             # are accepted values, defaults to PERMANENT.

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,8 @@ services:
         container_name: chhoto-url
         ports:
             # If you changed the "port" environment variable, adjust accordingly
-            # Both numbers before and after the colon should match the "port" variable
+            # The number AFTER the colon should match the "port" variable and the number
+            # before the colon is the port where you would access the container from outside.
             - 4567:4567
         environment:
             # Change if you want to mount the database somewhere else.


### PR DESCRIPTION
Hello again! I came across an issue when developing my extension, so I thought I'd make make a pull request with the code that fixed it.

Basically, I intuitively encapsulated my `site_url` environment variable with double quotes on my Chhoto URL instance. When this happens, the server returns an incorrect URL (as the host is surrounded by quotes). This PR adds code to check for this. Also, I made the binding port hard-coded to 4567. Instead, the `port` environment variable will affect what the server responds. This matches the style used by every other container that I use, and I think it's more intuitive this way. Feel free to change this as you see fit, though.

Other changes include:
- If the port is 80 or 443, remove the port from the returned URL (better for copying and pasting)
- Add documentation for the `port` environment variable in the compose file
- Improve documentation for the `site_url` environment variable in the compose file

Side note: you may notice that 2/3 of the commits are made by @SolomonTechnology. That's my other account. Just clearing that up. Also, the extension is now live at https://github.com/SolninjaA/Chhoto-URL-Extension. I just want to see the outcome of this PR before publishing to extension stores, since I'll have to edit code if you'd prefer not to merge this PR.