### PR TITLE
Add correct CORS header to routes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,0 @@
-SolninjaA <51935570+SolninjaA@users.noreply.github.com> <signup@solomon.tech>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+SolninjaA <51935570+SolninjaA@users.noreply.github.com> <signup@solomon.tech>

--- a/actix/Cargo.lock
+++ b/actix/Cargo.lock
@@ -20,6 +20,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more 0.99.18",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +494,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chhoto-url"
 version = "5.6.1"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-session",
  "actix-web",
@@ -738,6 +754,7 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]

--- a/actix/Cargo.toml
+++ b/actix/Cargo.toml
@@ -29,6 +29,7 @@ categories = ["web-programming"]
 [dependencies]
 actix-web = "4.5.1"
 actix-files = "0.6.5"
+actix-cors = "0.7.0"
 rusqlite = { version = "0.32.0", features = ["bundled"] }
 regex = "1.10.3"
 rand = "0.8.5"


### PR DESCRIPTION
Hello. I encountered a problem where some API requests would be blocked because of CORS, and so I did some testing and found that this CORS config works well. I originally attempted to only apply the CORS settings to the specific API routes, however after some research I couldn't find a way to do that.

This PR:
- Adds one dependency (actix-cors)
- Allows any origin to contact the server
- Only allows the `GET`, `POST` and `DELETE` methods
- Only allows the `X-API-Key` header

Thanks.