### PR TITLE
Optionally retry with a longer UID on collision

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -70,6 +70,10 @@ the `slug_length` variable. It defaults to 8, and a minimum of 4 is supported. I
 intend to have more than a few thousand shortlinks, it's strongly recommended that you 
 use the UID `slug_style` with a `slug_length` of 16 or more.
 
+If you do choose to use a short UID despite anticipating collisions, set `try_longer_slug` to `True`. 
+In the event of a collision, this variable will result in a single retry attempt using 
+a UID four digits longer than `slug_length`. It has no effect for adjective-name slugs.
+
 Although it's unlikely, it's possible that your database is mangled after some update. 
 For mission critical use cases, it's recommended to keep regular versioned backups of 
 the database, and sticking to a minor release tag e.g. 5.8. You can either bind mount a file

--- a/actix/src/config.rs
+++ b/actix/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub api_key: Option<String>,
     pub slug_style: String,
     pub slug_length: usize,
+    pub try_longer_slug: bool,
 }
 
 pub fn read() -> Config {
@@ -129,8 +130,14 @@ pub fn read() -> Config {
         .and_then(|s| s.parse::<usize>().ok())
         .filter(|&s| s >= 4)
         .unwrap_or(8);
+
+    let try_longer_slug = var("try_longer_slug").is_ok_and(|s| s.trim() == "True");
+
     if slug_style == "UID" {
         info!("Using UID slugs with length {slug_length}.");
+        if try_longer_slug {
+            info!("Will retry with a longer slug upon collision.")
+        };
     } else {
         info!("Using adjective-noun pair slugs.");
     }
@@ -149,5 +156,6 @@ pub fn read() -> Config {
         api_key,
         slug_style,
         slug_length,
+        try_longer_slug,
     }
 }

--- a/actix/src/database.rs
+++ b/actix/src/database.rs
@@ -82,7 +82,7 @@ pub fn add_hit(shortlink: &str, db: &Connection) {
 // Insert a new link
 pub fn add_link(
     shortlink: String,
-    longlink: String,
+    longlink: &str,
     expiry_delay: i64,
     db: &Connection,
 ) -> Result<i64, Error> {

--- a/actix/src/database.rs
+++ b/actix/src/database.rs
@@ -81,7 +81,7 @@ pub fn add_hit(shortlink: &str, db: &Connection) {
 
 // Insert a new link
 pub fn add_link(
-    shortlink: String,
+    shortlink: &str,
     longlink: &str,
     expiry_delay: i64,
     db: &Connection,

--- a/actix/src/utils.rs
+++ b/actix/src/utils.rs
@@ -157,14 +157,14 @@ pub fn add_link(req: String, db: &Connection, config: &Config) -> (bool, String,
                             db,
                         ) {
                             Ok(expiry_time) => (true, chunks.shortlink, expiry_time),
-                            Err(_) => (false, String::from("Something went wrong!"), 0),
+                            Err(_) => (false, String::from("Something went very wrong!"), 0),
                         }
                     } else {
-                        (false, String::from("Something went very wrong!"), 0)
+                        (false, String::from("Something went wrong!"), 0)
                     }
                 } else {
                     // This should be super rare
-                    (false, String::from("Something went wrong!"), 0)
+                    (false, String::from("Something went extremely wrong!"), 0)
                 }
             }
         }

--- a/compose.yaml
+++ b/compose.yaml
@@ -60,6 +60,8 @@ services:
             # The length is 8 by default, and a minimum of 4 is allowed.
             # - slug_style=Pair
             # - slug_length=8
+            # To retry (once) with a longer UID upon collision, change the following to True.
+            # - try_longer_slug=False
             
             # In case you want to provide public access to adding links (and not 
             # delete, or listing), change the following option to Enable.

--- a/helm-chart/templates/sts.yml
+++ b/helm-chart/templates/sts.yml
@@ -44,6 +44,8 @@ spec:
               value: {{ .Values.slug_style }}
             - name: slug_length
               value: "{{ .Values.slug_length }}"
+            - name: try_longer_slug
+              value: "{{ .Values.try_longer_slug }}"
             - name: public_mode
               value: {{ .Values.public_mode }}
             - name: disable_frontend

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -20,6 +20,7 @@ persistence:
 redirect_method: PERMANENT
 slug_style: Pair
 slug_length: 8
+try_longer_slug: False
 public_mode: Disable
 disable_frontend: False
 # cache_control_header: "no-cache, private"


### PR DESCRIPTION
Hello, this PR addresses #58. As we discussed there, it only takes effect if `try_longer_slug=True`.

A few notes:
* `database::add_link` now accepts `longlink` as a borrowed slice instead of a `String` because `utils::add_link` now calls it twice and would otherwise need to clone the string. I *think* that's right, but I don't write Rust regularly so I might have missed an implication there.
* To do a reasonable manual test of this, you need to set `slug_length=1` and so will need to hack out the line in config.rs which enforces a minimum slug length.
* There's a bit of duplication and extra nesting in `utils::add_link` now. I tried splitting it into a helper function, but on balance decided it was simpler this way. Similarly the `CHARS` array is duplicated for the test instead of splitting it out.

Happy to make any changes you need.