### PR TITLE
Fix incorrect relative URL and ensure correct protocol in copy function

### DIFF
--- a/resources/static/script.js
+++ b/resources/static/script.js
@@ -26,7 +26,7 @@ const prepSubdir = (link) => {
 };
 
 const hasProtocol = (url) => {
-  const regex = /[A-Za-z][A-Za-z0-9\+\-\.]*\:(?:\/\/)?/; // RFC 2396 Appendix A
+  const regex = /[A-Za-z][A-Za-z0-9\+\-\.]*\:(?:\/\/)?.*\D.*/; // RFC 2396 Appendix A
   return regex.test(url);
 };
 


### PR DESCRIPTION
This PR fixes an issue where a link was being rendered as a relative URL (e.g., href="example-path") instead of an absolute URL with the correct protocol. As a result, the browser sometimes appended the current domain, producing incorrect navigation paths.

Additionally, the copy‑to‑clipboard logic did not exactly match the clickable link, which could cause the copied URL to have the wrong protocol (http → https or vice versa).

Without this fix, users could be redirected to incorrect or broken URLs. This update ensures both navigation and clipboard behavior remain consistent and accurate.