### PR TITLE
Updated table styles to account for extremely long urls

### DIFF
--- a/resources/static/styles.css
+++ b/resources/static/styles.css
@@ -97,7 +97,7 @@ a {
 .chhoto-table th,
 .chhoto-table td {
   border-left: none;
-  max-width: 130em;
+  max-width: 42em;
 }
 
 #short-url-header {


### PR DESCRIPTION
I faced this issue while shortening an url with nearly 5000 chars (it is a working url!). The current `max-width` of `130em` for `.chhoto-table td`, kind of breaks the table with such a long url, even with a scrollbar. The screenshot below is before applying the fix.

<img width="2566" height="1265" alt="Screenshot 2025-08-18 at 15-13-42 Chhoto URL-blur" src="https://github.com/user-attachments/assets/7015bcf7-7ca4-469c-833e-8fb52ead84e1" />

PR to fix the issue by reducing the `max-width` to `42em` which aligns the table with the other elements, even for ultra long urls. The screenshot below after the fix.

<img width="2496" height="1240" alt="Screenshot 2025-08-18 at 15-12-52 Chhoto URL-blur" src="https://github.com/user-attachments/assets/e9ee3ba6-4118-4a20-a2c7-bab49a26774a" />

No impact to the mobile styles.
