### PR TITLE
new: Added support for pagination in the backend

### DIFF
--- a/actix/src/tests.rs
+++ b/actix/src/tests.rs
@@ -285,7 +285,7 @@ async fn data_fetching_all() {
 
     let req = test::TestRequest::get()
         .uri("/api/all")
-        .insert_header(("X-API-Key", api_key))
+        .insert_header(("X-API-Key", api_key.clone()))
         .to_request();
 
     let resp = test::call_service(&app, req).await;
@@ -301,6 +301,17 @@ async fn data_fetching_all() {
     assert_eq!(reply_chunks[1].hits, 0);
     assert_ne!(reply_chunks[0].expiry_time, 0);
     assert_ne!(reply_chunks[1].expiry_time, 0);
+
+    let req = test::TestRequest::get()
+        .uri("/api/all?page_no=1&page_size=1")
+        .insert_header(("X-API-Key", api_key))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let body = to_bytes(resp.into_body()).await.unwrap();
+    let reply_chunks: Vec<URLData> = serde_json::from_str(body.as_str()).unwrap();
+    assert_eq!(reply_chunks.len(), 1);
 
     let _ = fs::remove_file(format!("/tmp/chhoto-url-test-{test}.sqlite"));
 }

--- a/actix/src/utils.rs
+++ b/actix/src/utils.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use rusqlite::{ffi::SQLITE_CONSTRAINT_UNIQUE, Connection};
 use serde::{Deserialize, Serialize};
 
-use crate::{auth, config::Config, database};
+use crate::{auth, config::Config, database, services::GetReqParams};
 
 // Struct for reading link pairs sent during API call for new link
 #[derive(Deserialize)]
@@ -116,8 +116,10 @@ fn validate_link(link: &str, allow_capital_letters: bool) -> bool {
 }
 
 // Request the DB for all URLs
-pub fn getall(db: &Connection) -> String {
-    let links = database::getall(db);
+pub fn getall(db: &Connection, params: GetReqParams) -> String {
+    let page_no = params.page_no.filter(|&n| n > 0);
+    let page_size = params.page_size.filter(|&n| n > 0);
+    let links = database::getall(db, page_no, page_size);
     serde_json::to_string(&links).expect("Failure during creation of json from db.")
 }
 


### PR DESCRIPTION
The idea came from discussion in #97

## Backend
No page no means all results are returned, keeping backwards compatibility. Page no starts at 1, so <=0 values are ignored.
Floating point values will results in 400 errors. 

Same rules are held for page size.

If page no is provided, but no page size is provided, a default value of 10 is used.

## Frontend
The requests for data should look like `/api/all?page_no=n&page_size=s`. The params are optional. In the WebUI, we show 10 entries per page. The next and previous buttons are activated whenever there are more entries on either side. This is known by requesting for 2 pages at one time, and checking the length of the result. Also, this helps speed up the experience since the previous and next page always remain in cache.