### PR TITLE
chg: Renamed config variables

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -15,7 +15,7 @@ get the siteurl using `curl http://localhost:4567/api/siteurl`. These routes are
 
 **This is required for programs that rely on a JSON response from Chhoto URL**
 
-In order to use API key validation, set the `api_key` environment variable. If this is not set, the API will default to cookie
+In order to use API key validation, set the `CHHOTO_API_KEY` environment variable. If this is not set, the API will default to cookie
 validation (see section above). If the API key is insecure, a warning will be outputted along with a generated API key which may be used.
 
 **All responses for requests using API key are JSON encoded.**
@@ -209,7 +209,7 @@ request, please add `-b cookie.txt` to provide authentication. Unless specified,
 
 ## Disable authentication
 
-If you do not define a password environment variable when starting the docker image, authentication
+If you do not define a `CHHOTO_PASSWORD` environment variable when starting the docker image, authentication
 will be disabled.
 
 This if not recommended in actual use however, as it will allow anyone to create new links and delete

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,7 +21,7 @@ You can use the [provided compose file](./compose.yaml) as a base, modifying it 
 docker compose up -d
 ```
 
-If you're using a custom location for the `db_url`, and using WAL mode, make sure to mount a whole
+If you're using a custom location for the `CHHOTO_DB_URL`, and using WAL mode, make sure to mount a whole
 directory instead of a folder. If this is not done, there will be a low, but non-zero chance of data corruption.
 
 It should be possible to run Chhoto URL with pretty much anything that supports OCI images e.g. `docker`, `podman quadlets`
@@ -53,7 +53,7 @@ mentioned above., For any other architectures, open a discussion, and I'll try t
 
 ```
 docker run -p 4567:4567
-    -e password="password"
+    -e CHHOTO_PASSWORD="password"
     -d chhoto-url:latest
 ```
 
@@ -62,9 +62,9 @@ docker run -p 4567:4567
 ```
 touch ./urls.sqlite
 docker run -p 4567:4567 \
-    -e password="password" \
+    -e CHHOTO_PASSWORD="password" \
     -v ./data:/data \
-    -e db_url=/data/urls.sqlite \
+    -e CHHOTO_DB_URL=/data/urls.sqlite \
     -d chhoto-url:latest
 ```
 
@@ -75,21 +75,21 @@ that's what I use for testing. A sample file for podman quadlets is provided at
 ## Configuration options
 
 All the configuration is done using environmental variables. Here's a link of all supported ones. Please take
-a look at the ones marked with a `#` as those are important, especially [`use_wal_mode`](#use_wal_mode-).
+a look at the ones marked with a `#` as those are important, especially [`CHHOTO_USE_WAL_MODE`](#CHHOTO_USE_WAL_MODE-).
 
-### `db_url` \#
+### `CHHOTO_DB_URL` \#
 
-Location for the database file. Take a look at [`use_wal_mode`](#use_wal_mode-) before you change it. Defaults to
+Location for the database file. Take a look at [`CHHOTO_USE_WAL_MODE`](#CHHOTO_USE_WAL_MODE-) before you change it. Defaults to
 `urls.sqlite`. It is highly recommended that you mount a named volume or directory at a location like `/data` and
-use something like `/data/urls.sqlite` as `db_url`.
+use something like `/data/urls.sqlite` as `CHHOTO_DB_URL`.
 (Of course, the actual names being used don't really matter.)
 
-### `password` \#
+### `CHHOTO_PASSWORD` \#
 
 Provide a secure password. If kept empty, anyone can access the website. Note that password is not encrypted in
 transport, so it's recommended to use a reverse proxy like `caddy` or `nginx`.
 
-### `site_url` \#
+### `CHHOTO_SITE_URL` \#
 
 Change this to your public-facing URL. This is optional, as the link will work at any URL as long as Chhoto URL
 is accessible there. This mostly enhances the frontend experience, as copying to clipboard, QR code generation will
@@ -97,7 +97,7 @@ use it if available.
 Do not surround it using quotes. If you have any unicode characters, please use the punycode. It'll be automatically
 converted to the correct unicode in the frontend.
 
-### `api_key`
+### `CHHOTO_API_KEY`
 
 Provide a secure API key. It'll be checked at start for security. If the API key is considered weak, a strong API
 key will be generated and printed in the logs, but the weak one will be used for the time being.
@@ -107,7 +107,7 @@ Example Linux command for generating a secure API key: `tr -dc A-Za-z0-9 </dev/u
 If no API key is provided, the website will still work, but it'll be a significantly worse experience if you try
 to use Chhoto URL from the CLI.
 
-### `use_wal_mode` \#
+### `CHHOTO_USE_WAL_MODE` \#
 
 If set to `True`, enables [`WAL` journal mode](https://sqlite.org/wal.html). Any other value is ignored.
 It's highly recommended that you enable it, but make sure that you mount either a whole directory, or a named
@@ -120,9 +120,9 @@ Also, automated backups of the database will be enabled. Otherwise, `DELETE` jou
 used instead.
 
 In both cases, we have full ACID compliance, but it does cost a bit of performance. If you expect to see high throughput (in the
-order of hundreds of read/writes per second), take a look at the `ensure_acid` configuration option.
+order of hundreds of read/writes per second), take a look at the `CHHOTO_SQLITE_ENSURE_ACID` configuration option.
 
-### `ensure_acid`
+### `CHHOTO_SQLITE_ENSURE_ACID`
 
 By default, the database is
 [ACID (i.e. Atomic, Consistent, Isolated, and Durable)](https://www.slingacademy.com/article/acid-properties-in-sqlite-why-they-matter).
@@ -135,14 +135,14 @@ _Note: There might be partial data loss only in case of system failure or power 
 crashes. If you do have data loss, you should only lose the data stored after the last sync with the database file. So, under normal
 loads, you shouldn't lose any data anyway. But this is a real thing that can technically happen._
 
-### `redirect_method` \#
+### `CHHOTO_REDIRECT_METHOD` \#
 
 Sets which redirection is used when a shortlink is resolved.
 
 Can be set to `TEMPORARY` or `PERMANENT`, which will enable Temporary 307 or Permanent 308 redirects. Any other value
 will be ignored, and a default of `PERMANENT` will be used.
 
-### `slug_style`
+### `CHHOTO_SLUG_STYLE`
 
 Sets the style of slug used when auto-generating shortlinks.
 
@@ -150,40 +150,40 @@ Can be set to either `Pair` or `UID`. Any other value will be ignored, and a def
 In pair mode, adjective-name pairs are used for auto-generated links e.g. `gifted-ramanujan`. In UID mode, a randomly
 generated slug is used.
 
-### `slug_length`
+### `CHHOTO_SLUG_LENGTH`
 
 If UID slugs are enabled, the length of the slug can be set using this. A minimum of 4 is supported, and it defaults to 16.
-If you intend to have more than a few thousand shortlinks, it's strongly recommended that you use the UID `slug_style` with
-a `slug_length` of 16 or more.
+If you intend to have more than a few thousand shortlinks, it's strongly recommended that you use the UID `CHHOTO_SLUG_STYLE` with
+a `CHHOTO_SLUG_LENGTH` of 16 or more.
 
-### `try_longer_slug`
+### `CHHOTO_TRY_LONGER_SLUG`
 
 If you do choose to use a short UID despite anticipating collisions, it's recommended that you set this to `True`.
 In the event of a collision, this variable will result in a single retry attempt using a UID four digits longer than
-`slug_length`. It has no effect for adjective-name slugs.
+`CHHOTO_SLUG_LENGTH`. It has no effect for adjective-name slugs.
 
 _Note: If not set, one retry will be attempted, just like adjective-name slugs. But it would use the same slug length._
 
-### `listen_address`
+### `CHHOTO_LISTEN_ADDRESS`
 
 The address Chhoto URL will bind to. Defaults to `0.0.0.0`.
 
 Take a look at [this page](https://docs.rs/actix-web/4.11.0/actix_web/struct.HttpServer.html#method.bind)
-for supported values and potential consequences. Changing `listen_address` is not recommended if
+for supported values and potential consequences. Changing `CHHOTO_LISTEN_ADDRESS` is not recommended if
 using docker.
 
-### `port`
+### `CHHOTO_LISTEN_PORT`
 
 The port Chhoto URL will listen to. Defaults to `4567`.
 
-### `allow_capital_letters`
+### `CHHOTO_ALLOW_CAPITAL_LETTERS`
 
-If you want to use capital letters in the shortlink, set the `allow_capital_letters` variable to `True`. Any other
+If you want to use capital letters in the shortlink, set the `CHHOTO_ALLOW_CAPITAL_LETTERS` variable to `True`. Any other
 value is ignored.
 
 This will also allow capital letters in UID slugs, if those are enabled. It has no effect for adjective-name slugs.
 
-### `hash_algorithm` \#
+### `CHHOTO_HASH_ALGORITHM` \#
 
 If you want to provided hashed password and API Key, name a supported algorithm here. For now, the supported
 values are: `Argon2`. More algorithms may be added later. Unsupported values are ignored.
@@ -200,36 +200,47 @@ echo -n <password> | argon2 <salt> -id -t 3 -m 16 -l 32 -e
 
 You may also use online tools for this step.
 
-### `public_mode`
+### `CHHOTO_PUBLIC_MODE`
 
-To enable public mode, set `public_mode` to `Enable`. With this, anyone will be able to add
+To enable public mode, set `CHHOTO_PUBLIC_MODE` to `Enable`. With this, anyone will be able to add
 links. Listing existing links or deleting links will need admin access using the password. Any other values are
 ignored.
 
-### `public_mode_expiry_delay`
+### `CHHOTO_PUBLIC_MODE_EXPIRY_DELAY`
 
-If `public_mode` is enabled, and `public_mode_expiry_delay` is set to a positive value, submitted links
+If `CHHOTO_PUBLIC_MODE` is enabled, and `CHHOTO_PUBLIC_MODE_EXPIRY_DELAY` is set to a positive value, submitted links
 will expire in that given time (in seconds). The user can still choose a shorter expiry delay.
 
 It will have no effect for a logged in user i.e. the admin.
 
-### `disable_frontend`
+### `CHHOTO_DISABLE_FRONTEND`
 
 Set this to `True` to completely disable the frontend.
 
-### `custom_landing_directory`
+### `CHHOTO_CUSTOM_LANDING_DIRECTORY`
 
 If you want to serve a custom landing page, put all your site related files, along with a valid `index.html` file in a
 directory, and set this to the path of the directory. If using docker, you need to first
 mount the directory inside the container. The admin page will then be located at `/admin/manage`.
 
-### `cache_control_header`
+### `CHHOTO_CACHE_CONTROL_HEADER`
 
 By default, the server sends no Cache-Control headers. You can set custom headers here
 to send your desired headers. It must be a comma separated list of valid
 [RFC 7234 §5.2](https://datatracker.ietf.org/doc/html/rfc7234#section-5.2) headers. For example,
 you can set it to `no-cache, private` to disable caching. It might help during testing if
 served through a proxy.
+
+### `CHHOTO_FRONTEND_PAGE_SIZE`
+
+This can be used to set the number of items shown per page in the frontend. This does not have any effect on the backend code.
+Defaults to 10.
+
+## Note of eventual deprecation of old config options
+
+The config variables used to have different names up to commit 228eb7a, after which they were changed to adhere to norms for config variable
+naming. The old names will keep working for now, but _it is highly recommended to migrate to the new variable names_ as support for these
+will eventually be dropped in some future major release.
 
 ## Deploying in your Kubernetes cluster with Helm
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -75,11 +75,11 @@ that's what I use for testing. A sample file for podman quadlets is provided at
 ## Configuration options
 
 All the configuration is done using environmental variables. Here's a link of all supported ones. Please take
-a look at the ones marked with a `#` as those are important, especially [`CHHOTO_USE_WAL_MODE`](#CHHOTO_USE_WAL_MODE-).
+a look at the ones marked with a `#` as those are important, especially [`CHHOTO_SQLITE_USE_WAL_MODE`](#CHHOTO_SQLITE_USE_WAL_MODE-).
 
 ### `CHHOTO_DB_URL` \#
 
-Location for the database file. Take a look at [`CHHOTO_USE_WAL_MODE`](#CHHOTO_USE_WAL_MODE-) before you change it. Defaults to
+Location for the database file. Take a look at [`CHHOTO_SQLITE_USE_WAL_MODE`](#CHHOTO_SQLITE_USE_WAL_MODE-) before you change it. Defaults to
 `urls.sqlite`. It is highly recommended that you mount a named volume or directory at a location like `/data` and
 use something like `/data/urls.sqlite` as `CHHOTO_DB_URL`.
 (Of course, the actual names being used don't really matter.)
@@ -107,7 +107,7 @@ Example Linux command for generating a secure API key: `tr -dc A-Za-z0-9 </dev/u
 If no API key is provided, the website will still work, but it'll be a significantly worse experience if you try
 to use Chhoto URL from the CLI.
 
-### `CHHOTO_USE_WAL_MODE` \#
+### `CHHOTO_SQLITE_USE_WAL_MODE` \#
 
 If set to `True`, enables [`WAL` journal mode](https://sqlite.org/wal.html). Any other value is ignored.
 It's highly recommended that you enable it, but make sure that you mount either a whole directory, or a named

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ audit:
 	cargo audit --file actix/Cargo.lock
 
 podman-test: test podman-build podman-stop
-	podman run -t -p ${port}:${port} --name chhoto-url --env-file ./.env -v "${db_dir}:/data" -d chhoto-url
+	podman run -t -p ${CHHOTO_LISTEN_PORT}:${CHHOTO_LISTEN_PORT} --name chhoto-url --env-file ./.env -v "${DB_DIR}:/data" -d chhoto-url
 	podman logs chhoto-url -f 
 
 conf_tag := $(shell cat actix/Cargo.toml | sed -rn 's/^version = "(.+)"$$/\1/p')

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Password: `chhoto-url-demo-pass`
 - It started as a fork of [`simply-shorten`](https://gitlab.com/draganczukp/simply-shorten).
 - The list of adjectives and names used for random short url generation is a modified
   version of [this list used by docker](https://github.com/moby/moby/blob/master/pkg/namesgenerator/names-generator.go).
-- It is highly recommended that you [enable WAL mode](./INSTALLATION.md/#use_wal_mode-).
+- It is highly recommended that you [enable WAL mode](./INSTALLATION.md/#CHHOTO_SQLITE_USE_WAL_MODE-).
 - Although it's unlikely, it's possible that your database is mangled after some update. For mission critical use cases,
   it's recommended to keep regular versioned backups of the database, and sticking to a minor release tag e.g. 5.8.
 - If you intend to have more than a few thousand short links, it's strongly recommended that you use the UID `slug_style`

--- a/README.md
+++ b/README.md
@@ -120,5 +120,5 @@ Password: `chhoto-url-demo-pass`
 - It is highly recommended that you [enable WAL mode](./INSTALLATION.md/#CHHOTO_SQLITE_USE_WAL_MODE-).
 - Although it's unlikely, it's possible that your database is mangled after some update. For mission critical use cases,
   it's recommended to keep regular versioned backups of the database, and sticking to a minor release tag e.g. 5.8.
-- If you intend to have more than a few thousand short links, it's strongly recommended that you use the UID `slug_style`
-  with a `slug_length` of 16 or more. Otherwise, generating new links will start to fail after a while.
+- If you intend to have more than a few thousand short links, it's strongly recommended that you use the UID `CHHOTO_SLUG_STYLE`
+  with a `CHHOTO_SLUG_LENGTH` of 16 or more. Otherwise, generating new links will start to fail after a while.

--- a/actix/src/config.rs
+++ b/actix/src/config.rs
@@ -198,7 +198,7 @@ pub fn read() -> Config {
         info!("Capital letters won't be allowed in links.");
     }
 
-    let use_wal_mode = read_config_wrapper("CHHOTO_USE_WAL_MODE", "use_wal_mode")
+    let use_wal_mode = read_config_wrapper("CHHOTO_SQLITE_USE_WAL_MODE", "use_wal_mode")
         .is_ok_and(|s| s.trim() == "True");
     if use_wal_mode {
         info!("Using WAL journaling mode for database.");

--- a/actix/src/config.rs
+++ b/actix/src/config.rs
@@ -3,9 +3,23 @@
 
 use log::{info, warn};
 use passwords::{analyzer::analyze, scorer::score};
-use std::env::var;
+use std::env::{var, VarError};
 
 use crate::auth;
+
+fn read_config_wrapper(new_name: &str, old_name: &str) -> Result<String, VarError> {
+    // This is needed to support old variable names.
+    // Might be deprecated at a later point.
+    var(new_name).or_else(|e| match e {
+        VarError::NotPresent => var(old_name).inspect(|_| {
+            warn!(
+                "Variable {new_name} was not found, falling back to reading variable {old_name}."
+            );
+            warn!("Please consider updating your configs.");
+        }),
+        _ => Err(e),
+    })
+}
 
 // Struct for storing config read form env vars that might be accessed more than once
 #[derive(Clone)]
@@ -33,7 +47,7 @@ pub struct Config {
 }
 
 pub fn read() -> Config {
-    let db_location = var("db_url")
+    let db_location = read_config_wrapper("CHHOTO_DB_URL", "db_url")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
@@ -41,7 +55,7 @@ pub fn read() -> Config {
     info!("DB Location is set to: {db_location}");
 
     // Get the address environment variable
-    let listen_address = var("listen_address")
+    let listen_address = read_config_wrapper("CHHOTO_LISTEN_ADDRESS", "listen_address")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
@@ -49,25 +63,27 @@ pub fn read() -> Config {
     info!("Listening address is set to {listen_address}.");
 
     // Get the port environment variable
-    let port = var("port")
+    let port = read_config_wrapper("CHHOTO_LISTEN_PORT", "port")
         .unwrap_or(String::from("4567"))
         .parse::<u16>()
         .expect("Supplied port is not an integer");
     info!("Listening port is set to {port}.");
 
-    let cache_control_header = var("cache_control_header")
-        .ok()
-        .inspect(|h| info!("Using \"{h}\" as Cache-Control header."))
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
+    let cache_control_header =
+        read_config_wrapper("CHHOTO_CACHE_CONTROL_HEADER", "cache_control_header")
+            .ok()
+            .inspect(|h| info!("Using \"{h}\" as Cache-Control header."))
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
 
-    let disable_frontend = var("disable_frontend").is_ok_and(|s| s.trim() == "True");
+    let disable_frontend = read_config_wrapper("CHHOTO_DISABLE_FRONTEND", "disable_frontend")
+        .is_ok_and(|s| s.trim() == "True");
     if disable_frontend {
         info!("Frontend is disabled.")
     };
 
     // If an API key is set, check the security
-    let api_key = var("api_key").ok();
+    let api_key = read_config_wrapper("CHHOTO_API_KEY", "api_key").ok();
     if let Some(key) = &api_key {
         // Determine whether the inputted API key is sufficiently secure
         if score(&analyze(key)) < 90.0 {
@@ -77,11 +93,15 @@ pub fn read() -> Config {
         }
     }
 
-    let public_mode = var("public_mode") == Ok(String::from("Enable"));
-    let public_mode_expiry_delay = var("public_mode_expiry_delay")
-        .ok()
-        .and_then(|s| s.parse::<i64>().ok())
-        .unwrap_or_default();
+    let public_mode =
+        read_config_wrapper("CHHOTO_PUBLIC_MODE", "public_mode") == Ok(String::from("Enable"));
+    let public_mode_expiry_delay = read_config_wrapper(
+        "CHHOTO_PUBLIC_MODE_EXPIRY_DELAY",
+        "public_mode_expiry_delay",
+    )
+    .ok()
+    .and_then(|s| s.parse::<i64>().ok())
+    .unwrap_or_default();
     if public_mode {
         if public_mode_expiry_delay > 0 {
             info!("Enabling public mode with an enforced expiry delay of {public_mode_expiry_delay} seconds.");
@@ -90,25 +110,28 @@ pub fn read() -> Config {
         }
     }
 
-    let use_temp_redirect = var("redirect_method") == Ok(String::from("TEMPORARY"));
+    let use_temp_redirect = read_config_wrapper("CHHOTO_REDIRECT_METHOD", "redirect_method")
+        == Ok(String::from("TEMPORARY"));
     if use_temp_redirect {
         info!("Using Temporary redirection.");
     } else {
         info!("Using Permanent redirection (default).")
     }
 
-    let password = var("password").ok().filter(|s| !s.trim().is_empty());
+    let password = read_config_wrapper("CHHOTO_PASSWORD", "password")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
     if password.is_none() {
         warn!("No password was provided. The API will be accessible to the public.")
     };
 
-    let hash_algorithm = var("hash_algorithm")
+    let hash_algorithm = read_config_wrapper("CHHOTO_HASH_ALGORITHM", "hash_algorithm")
         .ok()
         .filter(|h| h == "Argon2")
         .inspect(|h| info!("Will use {h} hashes for password verification."));
 
     // If the site_url env variable exists
-    let site_url = if let Some(provided_url) = var("site_url")
+    let site_url = if let Some(provided_url) = read_config_wrapper("CHHOTO_SITE_URL", "site_url")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
@@ -121,7 +144,7 @@ pub fn read() -> Config {
         // If the site_url is encapsulated by quotes (i.e. invalid)
         if first == Option::from('"') || first == Option::from('\'') && first == last {
             // Set the site_url without the quotes
-            warn!("The site_url environment variable is encapsulated by quotes. Automatically adjusting to: {url}");
+            warn!("The CHHOTO_SITE_URL environment variable is encapsulated by quotes. Automatically adjusting to: {url}");
             Some(url.to_string())
         } else {
             info!("Configured Site URL is: {provided_url}");
@@ -130,7 +153,7 @@ pub fn read() -> Config {
     } else {
         // Site URL is not configured
         warn!(
-            "The site_url environment variable is not configured. Using http://localhost by default."
+            "The CHHOTO_SITE_URL environment variable is not configured. Using http://localhost by default."
         );
         let protocol = if port == 443 { "https" } else { "http" };
         let port_text = if [80, 443].contains(&port) {
@@ -143,18 +166,19 @@ pub fn read() -> Config {
         None
     };
 
-    let slug_style = var("slug_style")
+    let slug_style = read_config_wrapper("CHHOTO_SLUG_STYLE", "slug_style")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .unwrap_or(String::from("Pair"));
-    let slug_length = var("slug_length")
+    let slug_length = read_config_wrapper("CHHOTO_SLUG_LENGTH", "slug_length")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .filter(|&s| s >= 4)
         .unwrap_or(8);
 
-    let try_longer_slug = var("try_longer_slug").is_ok_and(|s| s.trim() == "True");
+    let try_longer_slug = read_config_wrapper("CHHOTO_TRY_LONGER_SLUG", "try_longer_slug")
+        .is_ok_and(|s| s.trim() == "True");
 
     if slug_style == "UID" {
         info!("Using UID slugs with length {slug_length}.");
@@ -165,20 +189,24 @@ pub fn read() -> Config {
         info!("Using adjective-noun pair slugs.");
     }
 
-    let allow_capital_letters = var("allow_capital_letters").is_ok_and(|s| s.trim() == "True");
+    let allow_capital_letters =
+        read_config_wrapper("CHHOTO_ALLOW_CAPITAL_LETTERS", "allow_capital_letters")
+            .is_ok_and(|s| s.trim() == "True");
     if allow_capital_letters {
         info!("Capital letters will be allowed in links.");
     } else {
         info!("Capital letters won't be allowed in links.");
     }
 
-    let use_wal_mode = var("use_wal_mode").is_ok_and(|s| s.trim() == "True");
+    let use_wal_mode = read_config_wrapper("CHHOTO_USE_WAL_MODE", "use_wal_mode")
+        .is_ok_and(|s| s.trim() == "True");
     if use_wal_mode {
         info!("Using WAL journaling mode for database.");
     } else {
         warn!("Using DELETE journaling mode for database. WAL mode is recommended.");
     }
-    let ensure_acid = !var("ensure_acid").is_ok_and(|s| s.trim() == "False");
+    let ensure_acid = !read_config_wrapper("CHHOTO_SQLITE_ENSURE_ACID", "ensure_acid")
+        .is_ok_and(|s| s.trim() == "False");
     if ensure_acid {
         let synchronous = if use_wal_mode { "FULL" } else { "EXTRA" };
         info!("Ensuring ACID compliance, using synchronous pragma: {synchronous}.");
@@ -187,16 +215,19 @@ pub fn read() -> Config {
         info!("Not ensuring ACID compliance, using synchronous pragma: {synchronous}.")
     }
 
-    let custom_landing_directory = var("custom_landing_directory")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .inspect(|s| {
-            info!("Custom landing directory is set to {s}.");
-            info!("The dashboard will be available at /admin/manage/");
-        });
+    let custom_landing_directory = read_config_wrapper(
+        "CHHOTO_CUSTOM_LANDING_DIRECTORY",
+        "custom_landing_directory",
+    )
+    .ok()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+    .inspect(|s| {
+        info!("Custom landing directory is set to {s}.");
+        info!("The dashboard will be available at /admin/manage/");
+    });
 
-    let frontend_page_size = var("frontend_page_size")
+    let frontend_page_size = var("CHHOTO_FRONTEND_PAGE_SIZE")
         .ok()
         .and_then(|s| s.parse::<u16>().ok())
         .filter(|&s| s >= 1)

--- a/chhoto-url.container
+++ b/chhoto-url.container
@@ -18,24 +18,26 @@ PublishPort=4567:4567
 DropCapability=ALL
 
 # Environment variables
-Environment=db_url=/db/urls.sqlite 
-Environment=use_wal_mode = True 
-#Environment=ensure_acid = True
-#Environment=site_url=https://www.example.com 
-#Environment=hash_algorithm=Argon2 
-Environment=password=TopSecretPass 
-Environment=port=4567
-#Environment=api_key=SECURE_API_KEY 
-Environment=redirect_method=TEMPORARY 
-Environment=slug_style=Pair 
-#Environment=slug_length=8 
-#Environment=try_longer_slug=False 
-#Environment=allow_capital_letters=False 
-#Environment=public_mode=Disable 
-#Environment=public_mode_expiry_delay=3600 
-#Environment=disable_frontend=False 
-#Environment=custom_landing_directory=/custom/dir/location 
-#Environment=cache_control_header=no-cache, private
+Environment=CHHOTO_DB_URL=/db/urls.sqlite 
+Environment=CHHOTO_SQLITE_USE_WAL_MODE = True 
+#Environment=CHHOTO_SQLITE_ENSURE_ACID = True
+#Environment=CHHOTO_SITE_URL=https://www.example.com 
+#Environment=CHHOTO_HASH_ALGORITHM=Argon2 
+Environment=CHHOTO_PASSWORD=TopSecretPass 
+Environment=CHHOTO_LISTEN_PORT=4567
+#Environment=CHHOTO_LISTEN_ADDRESS=4567
+#Environment=CHHOTO_API_KEY=SECURE_API_KEY 
+Environment=CHHOTO_REDIRECT_METHOD=TEMPORARY 
+Environment=CHHOTO_SLUG_STYLE=Pair 
+#Environment=CHHOTO_SLUG_LENGTH=8 
+#Environment=CHHOTO_TRY_LONGER_SLUG=False 
+#Environment=CHHOTO_ALLOW_CAPITAL_LETTERS=False 
+#Environment=CHHOTO_PUBLIC_MODE=Disable 
+#Environment=CHHOTO_PUBLIC_MODE_EXPIRY_DELAY=3600 
+#Environment=CHHOTO_DISABLE_FRONTEND=False 
+#Environment=CHHOTO_CUSTOM_LANDING_DIRECTORY=/custom/dir/location 
+#Environment=CHHOTO_CACHE_CONTROL_HEADER=no-cache, private
+#Environment=CHHOTO_FRONTEND_PAGE_SIZE=10
 
 # Volume
 Volume=db:/db

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,89 +11,93 @@ services:
     tty: true
     # You may enable the next two options if you want. Make sure that you run the container as the proper
     # user. In most cases, user: 1000:1000 should work. You might also need to mount a directory with your
-    # db and not just the file itself. Make sure to adjust db_url accordingly.
+    # db and not just the file itself. Make sure to adjust CHHOTO_DB_URL accordingly.
     # It does add extra security, but I don't know enough about docker to help in case it breaks something.
     # read_only: true
     # cap_drop:
     #   - ALL
     ports:
-      # If you changed the "port" environment variable, adjust accordingly
-      # The number AFTER the colon should match the "port" variable and the number
+      # If you changed the "CHHOTO_LISTEN_PORT" environment variable, adjust accordingly
+      # The number AFTER the colon should match the "CHHOTO_LISTEN_PORT" variable and the number
       # before the colon is the port where you would access the container from outside.
       - 4567:4567
     environment:
       # Change if you want to mount the database somewhere else.
       # In this case, you can get rid of the db volume below
       # and instead do a mount manually by specifying the location.
-      - db_url=/db/urls.sqlite
+      - CHHOTO_DB_URL=/db/urls.sqlite
       # Uncomment the next line to enable WAL mode. It's highly recommended.
       # Make sure that you mount a directory instead of a bare file
       # since that might have a (low, but non-zero) possibility of
       # corrupting your db since we use WAL journaling mode
       # (In fact, I'd suggest that you do that so that you can keep
       # a copy of your database.)
-      # - use_wal_mode = True
+      # - CHHOTO_SQLITE_USE_WAL_MODE = True
       # If you'd like to disable ACID compliance, uncomment the next line.
       # Note that there are risks. Look at the README for more.
-      # - ensure_acid = False
+      # - CHHOTO_SQLITE_ENSURE_ACID = False
 
       # Change this to your public-facing URL. This is optional, as the link will work at any URL as
       # long as Chhoto URL is accessible there. This mostly enhances the frontend experience, as copying to clipboard,
       # QR code generation will use it if available.
       # Do not surround it using quotes. If you have any unicode characters, please use the punycode. It'll be
       # automatically converted to the correct unicode in the frontend.
-      # - site_url=https://www.example.com
+      # - CHHOTO_SITE_URL=https://www.example.com
 
       # If you want to provided hashed password and API Key, uncomment the next line. Read the README
       # for instructions for the hashing. Make sure to escape $ by $$.
-      # - hash_algorithm=Argon2
+      # - CHHOTO_HASH_ALGORITHM=Argon2
 
-      # Change this if you are running Chhoto URL on a port which is not 4567.
-      # This is important to ensure Chhoto URL outputs the shortened link with the correct port.
-      # - port=4567
+      # Change this if you are want to run Chhoto URL on a port which is not 4567, bind to something other
+      # than 0.0.0.0 for the backend. Do not change this unless you know what you're doing.
+      # - CHHOTO_LISTEN_PORT=4567
+      # - CHHOTO_LISTEN_ADDRESS=0.0.0.0
 
       - password=TopSecretPass
 
       # This needs to be set in order to use programs that use the JSON interface of Chhoto URL.
       # You will get a warning if this is insecure, and a generated value will be output
       # You may use that value if you can't think of a secure key
-      # - api_key=SECURE_API_KEY
+      # - CHHOTO_API_KEY=SECURE_API_KEY
 
       # Pass the redirect method, if needed. TEMPORARY and PERMANENT
       # are accepted values, defaults to PERMANENT.
-      # - redirect_method=TEMPORARY
+      # - CHHOTO_REDIRECT_METHOD=TEMPORARY
 
       # By default, the auto-generated pairs are adjective-name pairs.
       # If you want UIDs, please change slug_style to UID.
       # Supported values for slug_style are Pair and UID.
       # The length is 8 by default, and a minimum of 4 is allowed.
-      # - slug_style=Pair
-      # - slug_length=8
+      # - CHHOTO_SLUG_STYLE=Pair
+      # - CHHOTO_SLUG_LENGTH=8
       # To retry (once) with a longer UID upon collision, change the following to True.
-      # - try_longer_slug=False
+      # - CHHOTO_TRY_LONGER_SLUG=False
       # If you want to use capital letters in the shortlink, change the following to
       # True. This will also allow capital letters in UID slugs, if it is enabled.
-      # - allow_capital_letters=False
+      # - CHHOTO_ALLOW_CAPITAL_LETTERS=False
 
       # In case you want to provide public access to adding links (and not
       # delete, or listing), change the following option to Enable.
-      # - public_mode=Disable
+      # - CHHOTO_PUBLIC_MODE=Disable
       # Additionally, it's possible to force an expiry delay in public mode.
       # The user can still choose a shorter expiry delay. The input must be in seconds.
       # It defaults to 0 i.e. no expiry.
-      # - public_mode_expiry_delay=3600
+      # - CHHOTO_PUBLIC_MODE_EXPIRY_DELAY=3600
       # In case you want to completely disable the frontend, change the following
       # to True.
-      # - disable_frontend=False
+      # - CHHOTO_DISABLE_FRONTEND=False
       # If you want to serve a custom landing page, put all your site related files, along with an
       # index.html file in a directory, and set the following to the path of the directory. Remember to first
       # mount the directory inside the container. The admin page will then be located at /admin/manage.
-      # - custom_landing_directory=/custom/dir/location
+      # - CHHOTO_CUSTOM_LANDING_DIRECTORY=/custom/dir/location
 
       # By default, the server sends no Cache-Control headers. You can supply a
       # comma separated list of valid header as per RFC 7234 §5.2 to send those
       # headers instead.
-      # - cache_control_header=no-cache, private
+      # - CHHOTO_CACHE_CONTROL_HEADER=no-cache, private
+      # By default, the frontend paginates the shortlinks in pages of size 10. You can use the following to
+      # customize that.
+      # CHHOTO_FRONTEND_PAGE_SIZE=10
 
       # You may set the TZ variable for timezone in logging, but it will only work in the alpine builds
     volumes:


### PR DESCRIPTION
Now all config variable names start with CHHOTO_ and are capitalized. This is what most other pieces of software do, and makes it easier for Chhoto URL to share space with other apps.

**The older variable names will still be used as fallback**, so existing deployments will keep working. But it might be deprecated at some future major release, and it's highly recommended to migrate to the new variable names.