### PR TITLE
new: Added support for allowing extra protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![docker-pulls-badge](https://img.shields.io/docker/pulls/sintan1729/chhoto-url?logo=docker&label=pulls)](https://hub.docker.com/r/sintan1729/chhoto-url)
 [![ghcr-pulls-badge](https://img.shields.io/badge/dynamic/json?url=https://ghcr-badge.elias.eu.org/api/SinTan1729/chhoto-url&query=downloadCount&label=pulls&style=flat&logo=github)](https://ghcr.io/SinTan1729/chhoto-url)
 [![github-stars-badge](https://img.shields.io/github/stars/SinTan1729/chhoto-url?logo=github&style=flat)](https://github.com/SinTan1729/chhoto-url)
-[![codeberg-stars-badge](https://img.shields.io/gitea/stars/SinTan1729/chhoto-url?gitea_url=https%3A%2F%2Fcodeberg.org&style=flat&logo=codeberg
-)](https://codeberg.org/SinTan1729/chhoto-url)
+[![codeberg-stars-badge](https://img.shields.io/gitea/stars/SinTan1729/chhoto-url?gitea_url=https%3A%2F%2Fcodeberg.org&style=flat&logo=codeberg)](https://codeberg.org/SinTan1729/chhoto-url)
 [![maintainer-badge](https://img.shields.io/badge/maintainer-SinTan1729-blue?logo=github)](https://github.com/SinTan1729)
 [![latest-release-badge](https://img.shields.io/github/v/release/SinTan1729/chhoto-url?logo=github)](https://github.com/SinTan1729/chhoto-url/releases/latest)
 [![docker-image-size-badge](https://img.shields.io/docker/image-size/sintan1729/chhoto-url?logo=docker&label=size)](https://hub.docker.com/r/sintan1729/chhoto-url/tags)
@@ -130,5 +129,5 @@ Password: `chhoto-url-demo-pass`
 - If you intend to have more than a few thousand short links, it's strongly recommended that you use the UID
   [`CHHOTO_SLUG_STYLE`](./docs/INSTALLATION.md#chhoto_slug_style) with a [`CHHOTO_SLUG_LENGTH`](./docs/INSTALLATION.md#chhoto_slug_length)
   of 16 or more. Otherwise, generating new links will start to fail after a while.
-- For safety, only `https`,`http`,`ftp`, and `magnet` links are allowed for long links. If you have a special case which requires some
-  specific scheme, feel free to open a feature request, and we can figure out a solution.
+- For safety, only `https`,`http`,`ftp`, and `magnet` links are allowed for long links by default. Please take a look at
+  [`CHHOTO_EXTRA_PROTOCOLS`](./docs/INSTALLATION.md#chhoto_extra_protocols) to use more protocols.

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -117,6 +117,7 @@ pub(crate) struct Config {
     pub(crate) public_mode: bool,
     pub(crate) public_mode_expiry_delay: Option<i64>,
     pub(crate) use_temp_redirect: bool,
+    pub(crate) allowed_protocols: Vec<String>,
     pub(crate) password: Option<String>,
     pub(crate) hash_algorithm: HashAlgorithm,
     pub(crate) api_key: Option<String>,
@@ -201,6 +202,21 @@ pub(crate) fn read() -> Config {
     } else {
         info!("Using Permanent redirection (default).")
     }
+
+    let mut allowed_protocols: Vec<String> = ["http", "https", "ftp", "magnet"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    if let Ok(protocols) = var("CHHOTO_EXTRA_PROTOCOLS") {
+        for protocol in protocols.split(&[',', ' ']).filter(|p| !p.is_empty()) {
+            if protocol.chars().all(|c| c.is_alphanumeric()) {
+                allowed_protocols.push(protocol.to_owned());
+            } else {
+                warn!("Skipping malformed protocol: {protocol}.")
+            }
+        }
+    }
+    info!("Allowed protocols: {:?}", allowed_protocols);
 
     let password = read_config_wrapper("CHHOTO_PASSWORD", "password")
         .ok()
@@ -334,6 +350,7 @@ pub(crate) fn read() -> Config {
         public_mode,
         public_mode_expiry_delay,
         use_temp_redirect,
+        allowed_protocols,
         password,
         hash_algorithm,
         api_key,

--- a/backend/src/services/get.rs
+++ b/backend/src/services/get.rs
@@ -99,6 +99,7 @@ pub(crate) async fn getconfig(auth: Auth, data: web::Data<AppState>) -> HttpResp
             allow_capital_letters: config.allow_capital_letters,
             public_mode: config.public_mode,
             public_mode_expiry_delay: config.public_mode_expiry_delay.unwrap_or_default(),
+            allowed_protocols: config.allowed_protocols.clone(),
             site_url: config.site_url.clone(),
             slug_style: config.slug_style.to_string(),
             slug_length: config.slug_length,

--- a/backend/src/services/types.rs
+++ b/backend/src/services/types.rs
@@ -42,6 +42,7 @@ pub(super) struct BackendConfig {
     pub(super) allow_capital_letters: bool,
     pub(super) public_mode: bool,
     pub(super) public_mode_expiry_delay: i64,
+    pub(super) allowed_protocols: Vec<String>,
     pub(super) slug_style: String,
     pub(super) slug_length: usize,
     pub(super) try_longer_slug: bool,

--- a/backend/src/services/utils.rs
+++ b/backend/src/services/utils.rs
@@ -43,9 +43,9 @@ struct EditURLRequest {
 
 // Only allow safe URI schemes
 #[inline]
-fn is_longlink_valid(link: &str) -> bool {
+fn is_longlink_valid(link: &str, allowed_protocols: &[String]) -> bool {
     let parts = Url::parse(link);
-    parts.is_ok_and(|u| ["http", "https", "ftp", "magnet"].contains(&u.scheme()))
+    parts.is_ok_and(|u| allowed_protocols.contains(&u.scheme().to_owned()))
 }
 
 // Only have a-z, 0-9, - and _ as valid characters in a shortlink
@@ -192,7 +192,7 @@ pub(super) fn add_links_helper(
             output[i] = Err(ClientError {
                 reason: "Invalid shortlink!".to_owned(),
             });
-        } else if !is_longlink_valid(&req.longlink) {
+        } else if !is_longlink_valid(&req.longlink, &config.allowed_protocols) {
             output[i] = Err(ClientError {
                 reason: "Invalid longlink!".to_owned(),
             });
@@ -272,7 +272,7 @@ pub(super) async fn edit_link_helper(
         return Err(ClientError {
             reason: "Invalid shortlink!".to_owned(),
         });
-    } else if !is_longlink_valid(&chunks.longlink) {
+    } else if !is_longlink_valid(&chunks.longlink, &config.allowed_protocols) {
         return Err(ClientError {
             reason: "Invalid longlink!".to_owned(),
         });

--- a/backend/src/tests/insertion.rs
+++ b/backend/src/tests/insertion.rs
@@ -235,6 +235,23 @@ async fn adding_link_with_retry_on_collision() {
 }
 
 #[test]
+async fn adding_links_with_custom_protocol() {
+    let test = "custom-protocols";
+    let mut conf = default_config(test);
+    conf.allowed_protocols.push("ftps".to_string());
+    let (_tempdir, app) = create_app(&conf, test).await;
+    let api_key = conf.api_key.clone().unwrap();
+    let req = test::TestRequest::post()
+        .uri("/api/new")
+        .insert_header(("X-API-Key", api_key.clone()))
+        .set_payload(r#"{{"shortlink":"test","longlink":"ftps://example.com","notes":"note"}}"#)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    assert!(status.is_client_error());
+}
+
+#[test]
 async fn link_editing() {
     let test = "link-editing";
     let conf = default_config(test);

--- a/backend/src/tests/utils.rs
+++ b/backend/src/tests/utils.rs
@@ -54,6 +54,7 @@ pub(super) fn default_config(test: &str) -> config::Config {
         public_mode: false,
         public_mode_expiry_delay: None,
         use_temp_redirect: false,
+        allowed_protocols: Vec::from(["http", "https", "ftp", "magnet"].map(|s| s.to_string())),
         password: Some(String::from("testpass")),
         hash_algorithm: config::HashAlgorithm::None,
         api_key: Some(String::from(

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -97,7 +97,10 @@ services:
       # - CHHOTO_CACHE_CONTROL_HEADER=no-cache, private
       # By default, the frontend paginates the shortlinks in pages of size 10. You can use the following to
       # customize that.
-      # CHHOTO_FRONTEND_PAGE_SIZE=10
+      # - CHHOTO_FRONTEND_PAGE_SIZE=10
+      # Use this to allow extra protocols for longlinks. By default, only `http`, `https`, `ftp`, and `magnet` links are allowed.
+      # It should be a comma separated list. Malformed protocols will be skipped.
+      # - CHHOTO_EXTRA_PROTOCOLS=ftps,obsidian
 
       # You may set the TZ variable for timezone in logging, but it will only work in the alpine builds
     volumes:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -267,6 +267,11 @@ served through a proxy.
 This can be used to set the number of items shown per page in the frontend. This does not have any effect on the backend code.
 Defaults to 10.
 
+### `CHHOTO_EXTRA_PROTOCOLS`
+
+Use this to allow extra protocols for longlinks. By default, only `http`, `https`, `ftp`, and `magnet` links are allowed. It should be a comma
+separated list e.g. `ftps,obsidian`. Malformed protocols will be skipped.
+
 ### `RUST_LOG`
 
 It controls the level of logging.

--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -131,7 +131,7 @@ const getConfig = async () => {
     CONFIG.frontend_page_size = 10;
   }
 
-  if (!["http", "https"].includes(new URL(SITE_URL).protocol)) {
+  if (!["http:", "https:"].includes(new URL(SITE_URL).protocol)) {
     SITE_URL = window.location.protocol + "//" + SITE_URL;
   }
 

--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -86,7 +86,7 @@ const prepSubdir = (link) => {
 };
 
 const hasAllowedScheme = (url) => {
-  const allowedSchemes = ["http:", "https:", "ftp:", "magnet:"];
+  const allowedSchemes = CONFIG.allowed_protocols.map((s) => s + ":");
   try {
     return allowedSchemes.includes(new URL(url).protocol);
   } catch {
@@ -131,7 +131,7 @@ const getConfig = async () => {
     CONFIG.frontend_page_size = 10;
   }
 
-  if (!hasAllowedScheme(SITE_URL)) {
+  if (!["http", "https"].includes(new URL(SITE_URL).protocol)) {
     SITE_URL = window.location.protocol + "//" + SITE_URL;
   }
 


### PR DESCRIPTION
This PR will add support for allowing extra protocols using the env variable `CHHOTO_EXTRA_PROTOCOLS`. It must be a comma separated string of protocols e.g. `ftps,obsidian`.

Fixes #131 